### PR TITLE
Bump setup-terraform action to v1.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         aws-region: us-west-2
 
     - name: Terraform Setup
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v1.2.1
       with:
         terraform_version: ${{ env.tf_version }}
 


### PR DESCRIPTION
It appears that Hashicorp is treating v1 as an immutable tag,
so we're not getting minor version updates as we were expecting.

This update resolves CVE-2020-15228, so we shouldn't get the
warnings related to `set-env` and `add-path`.