### PR TITLE
Fix Deprecated Github Commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         aws-access-key-id: ${{ secrets.BYU_ORG_SERVICE_KEY }}
         aws-secret-access-key: ${{ secrets.BYU_ORG_SERVICE_SECRET }}


### PR DESCRIPTION
This is a best attempt pull request to upgrade outdated actions. Failure to upgrade may mean your actions stop working on June 1st, 2023. We only targeted one branch (usually development) and you can deploy those changes to other branches. Some workflows may need extra tweaking to work. Feel free to contact Jamie Visker if you have questions or want another branch targeted.